### PR TITLE
Update Links with Username

### DIFF
--- a/components/dashboard/CheckUsername.tsx
+++ b/components/dashboard/CheckUsername.tsx
@@ -5,32 +5,22 @@ import { auth } from "@/pages/_app";
 import Modal from "../ui/Modal";
 import Input from "../ui/Input";
 
-const CheckUsername = () => {
-  const { user, hasUsername, setUsername, checkUsernameValidity } = useUser();
-  const [showUsernameModal, setShowUsernameModal] = useState(true);
+const CheckUsername = ({
+  show,
+  onSetShow,
+}: {
+  show: boolean;
+  onSetShow: (state: boolean) => void;
+}) => {
+  const { user, setUsername, checkUsernameValidity } = useUser();
   const [input, setInput] = useState("");
   const [invalidUsername, setInvalidUsername] = useState(false);
-
-  useEffect(() => {
-    (async () => {
-      const user = auth.currentUser;
-      if (!user) return;
-      try {
-        const userHasUsername = await hasUsername(user);
-        if (userHasUsername) {
-          setShowUsernameModal(false);
-        }
-      } catch (error) {
-        console.log("Error checking username: ", error);
-      }
-    })();
-  }, []);
 
   const onUsernameSet = async (username: string) => {
     if (!user) return;
     try {
       await setUsername(user.uid, username);
-      setShowUsernameModal(false);
+      onSetShow(false);
     } catch (error) {
       toast.error("Error setting username");
       setInvalidUsername(true);
@@ -53,8 +43,8 @@ const CheckUsername = () => {
 
   return (
     <Modal
-      isOpen={showUsernameModal}
-      setIsOpen={setShowUsernameModal}
+      isOpen={show}
+      setIsOpen={onSetShow}
       saveText="Save"
       title="Set Username"
       description="Set a username to create your personal writedown space."

--- a/components/dashboard/Sidebar/index.tsx
+++ b/components/dashboard/Sidebar/index.tsx
@@ -12,6 +12,7 @@ import { isSyncedAtom } from "@/stores/syncedAtom";
 import React, { useEffect, useState } from "react";
 import BetaBadge from "@/components/ui/BetaBadge";
 import { BsChevronBarLeft } from "react-icons/bs";
+import useUser from "@/components/hooks/useUser";
 import Popover from "@/components/ui/Popover";
 import Skeleton from "react-loading-skeleton";
 import Button from "@/components/ui/Button";
@@ -32,7 +33,7 @@ const Sidebar = ({
   setShowSidebar,
 }: SidebarProps & IFirebaseAuth) => {
   const router = useRouter();
-  const [user] = useAuthState(auth);
+  const { user, publicUserDetails } = useUser();
 
   const [mounted, setMounted] = useState(false);
   const [createPostLoading, setCreatePostLoading] = useState(false);
@@ -173,7 +174,7 @@ const Sidebar = ({
                 key={note.id}
                 as={
                   note.public
-                    ? `/${note.userId}/posts/${note.slug}`
+                    ? `/${publicUserDetails?.username}/posts/${note.slug}`
                     : `/dashboard/?post=${note.slug}`
                 }
               >

--- a/components/dashboard/TextArea/PostButtons.tsx
+++ b/components/dashboard/TextArea/PostButtons.tsx
@@ -71,16 +71,12 @@ const PostButtons = ({ shiftRight, editor }: PostButtonsProps) => {
   const postContent = useAtomValue(postContentAtom);
   const postTitle = useAtomValue(postTitleAtom);
 
-  const { user } = useUser();
+  const { user, publicUserDetails } = useUser();
 
   // CUSTOM HOOKS
   const { notes, updateNote, deleteNote, refreshNotes } = useNotes({
     userId: user?.uid,
   });
-
-  const [userDetails] = useDocumentData(
-    user ? doc(db, "users", user?.uid).withConverter(userDocConverter) : null
-  );
 
   // EFFECTS
   useEffect(() => {
@@ -296,10 +292,10 @@ const PostButtons = ({ shiftRight, editor }: PostButtonsProps) => {
                 navigator.clipboard.writeText(
                   isDev
                     ? `http://localhost:3000/${
-                        userDetails?.username || userDetails?.uid
+                        publicUserDetails?.username || publicUserDetails?.uid
                       }/posts/${selectedNoteId}`
                     : `https://writedown.app/${
-                        userDetails?.username || userDetails?.uid
+                        publicUserDetails?.username || publicUserDetails?.uid
                       }/posts/${selectedNoteId}`
                 );
               }}
@@ -309,7 +305,7 @@ const PostButtons = ({ shiftRight, editor }: PostButtonsProps) => {
                 {process.env.NODE_ENV !== "development" &&
                   postPublic &&
                   `https://writedown.app/${
-                    userDetails?.username || userDetails?.uid
+                    publicUserDetails?.username || publicUserDetails?.uid
                   }/posts/${selectedNoteId}`}
                 {process.env.NODE_ENV !== "development" &&
                   !postPublic &&
@@ -318,7 +314,7 @@ const PostButtons = ({ shiftRight, editor }: PostButtonsProps) => {
                 {process.env.NODE_ENV === "development" &&
                   postPublic &&
                   `http://localhost:3000/${
-                    userDetails?.username || userDetails?.uid
+                    publicUserDetails?.username || publicUserDetails?.uid
                   }/posts/${selectedNoteId}`}
                 {process.env.NODE_ENV === "development" &&
                   !postPublic &&

--- a/components/hooks/useUser.ts
+++ b/components/hooks/useUser.ts
@@ -19,6 +19,17 @@ export const useUser = () => {
    * default values
    * @param user
    */
+
+  const checkUserExists = async (user: User) => {
+    const userRef = doc(db, "users", user.uid);
+    try {
+      const userSnap = await getDoc(userRef);
+      return userSnap.exists();
+    } catch (error) {
+      throw error;
+    }
+  };
+
   const createUser = async (user: User) => {
     if (!user) {
       throw new Error("User not found");
@@ -108,6 +119,7 @@ export const useUser = () => {
     setUsername,
     checkUsernameValidity,
     hasUsername,
+    checkUserExists,
   };
 };
 

--- a/components/hooks/useUser.ts
+++ b/components/hooks/useUser.ts
@@ -1,4 +1,6 @@
 import { deleteDoc, doc, getDoc, setDoc, writeBatch } from "firebase/firestore";
+import { userDocConverter } from "@/utils/firestoreDataConverter";
+import { useDocumentData } from "react-firebase-hooks/firestore";
 import { UserDocument } from "@/types/utils/firebaseOperations";
 import { useAuthState } from "react-firebase-hooks/auth";
 import { User, UserProfile } from "firebase/auth";
@@ -7,6 +9,10 @@ import { auth } from "@/pages/_app";
 
 export const useUser = () => {
   const [user] = useAuthState(auth);
+
+  const [publicUserDetails] = useDocumentData(
+    user ? doc(db, "users", user?.uid).withConverter(userDocConverter) : null
+  );
 
   /**
    * Create a new user document in firestore with
@@ -94,7 +100,15 @@ export const useUser = () => {
     }
   };
 
-  return { user, createUser, setUsername, checkUsernameValidity, hasUsername };
+  return {
+    user,
+    /** The user document with public details */
+    publicUserDetails,
+    createUser,
+    setUsername,
+    checkUsernameValidity,
+    hasUsername,
+  };
 };
 
 export default useUser;

--- a/components/hooks/useUser.ts
+++ b/components/hooks/useUser.ts
@@ -7,6 +7,7 @@ import { auth } from "@/pages/_app";
 
 export const useUser = () => {
   const [user] = useAuthState(auth);
+
   /**
    * Create a new user document in firestore with
    * default values

--- a/firestore.rules
+++ b/firestore.rules
@@ -22,7 +22,7 @@ service cloud.firestore {
     }
 
     match /usernames/{username} {
-      allow read: if request.auth != null;
+      allow read;
       allow create: if isValidUsername(username);
     }
 

--- a/pages/[username]/posts/[postId].tsx
+++ b/pages/[username]/posts/[postId].tsx
@@ -4,6 +4,7 @@ import { ReactMarkdown } from "react-markdown/lib/react-markdown";
 import { useAuthState } from "react-firebase-hooks/auth";
 import UserMenu from "@/components/common/UserMenu";
 import HeadTags from "@/components/common/HeadTags";
+import useUser from "@/components/hooks/useUser";
 import { doc, getDoc } from "firebase/firestore";
 import Footer from "@/components/home/Footer";
 import { RiMenu5Fill } from "react-icons/ri";
@@ -20,7 +21,7 @@ interface Props {
 }
 
 export const PostPage = ({ note, name, profilePicture }: Props) => {
-  const [user] = useAuthState(auth);
+  const { user } = useUser();
 
   return (
     <>
@@ -132,8 +133,6 @@ export const getServerSideProps: GetServerSideProps = async (context) => {
       notFound: true,
     };
   }
-
-  console.log("user", user);
 
   try {
     const noteDoc = doc(db, "users", user.uid, "notes", postId as string);

--- a/pages/[username]/posts/[postId].tsx
+++ b/pages/[username]/posts/[postId].tsx
@@ -107,33 +107,36 @@ export const PostPage = ({ note, name, profilePicture }: Props) => {
 };
 
 export const getServerSideProps: GetServerSideProps = async (context) => {
-  const {
-    postId,
-    // username is the uid
-    username,
-  } = context.query;
+  const { postId, username } = context.query;
 
   let user: UserDocument;
   let note: NoteDocument;
 
   try {
-    const userDoc = doc(db, "users", username as string);
-    const userSnapshot = await getDoc(userDoc);
-    user = userSnapshot.data() as UserDocument;
+    const usernameDoc = doc(db, "usernames", username as string);
+    const usernameSnapshot = await getDoc(usernameDoc);
+    const usernameData = usernameSnapshot.data();
+    if (usernameData) {
+      const userDoc = doc(db, "users", usernameData.uid as string);
+      const userSnapshot = await getDoc(userDoc);
+      user = userSnapshot.data() as UserDocument;
+    } else {
+      const uid = username as string;
+      const userDoc = doc(db, "users", uid);
+      const userSnapshot = await getDoc(userDoc);
+      user = userSnapshot.data() as UserDocument;
+    }
   } catch (error) {
+    console.log(error);
     return {
       notFound: true,
     };
   }
 
+  console.log("user", user);
+
   try {
-    const noteDoc = doc(
-      db,
-      "users",
-      username as string,
-      "notes",
-      postId as string
-    );
+    const noteDoc = doc(db, "users", user.uid, "notes", postId as string);
     const noteSnapshot = await getDoc(noteDoc);
     note = noteSnapshot.data() as NoteDocument;
   } catch (error) {

--- a/pages/dashboard.tsx
+++ b/pages/dashboard.tsx
@@ -3,15 +3,34 @@ import { useAuthState } from "react-firebase-hooks/auth";
 import TextArea from "@/components/dashboard/TextArea";
 import Sidebar from "@/components/dashboard/Sidebar";
 import HeadTags from "@/components/common/HeadTags";
+import React, { useEffect, useState } from "react";
+import useUser from "@/components/hooks/useUser";
 import { useRouter } from "next/router";
-import React, { useState } from "react";
 import { auth } from "./_app";
 
 const Dashboard = () => {
   // NEXT ROUTER
   const router = useRouter();
 
+  const { user, hasUsername } = useUser();
+
+  const [showUsernameModal, setShowUsernameModal] = useState(false);
   const [showSidebar, setShowSidebar] = useState(true);
+
+  useEffect(() => {
+    (async () => {
+      const user = auth.currentUser;
+      if (!user) return;
+      try {
+        const userHasUsername = await hasUsername(user);
+        if (!userHasUsername) {
+          setShowUsernameModal(true);
+        }
+      } catch (error) {
+        console.log("Error checking username: ", error);
+      }
+    })();
+  }, [user]);
 
   // AUTH STATE HOOK
   useAuthState(auth, {
@@ -34,7 +53,12 @@ const Dashboard = () => {
         />
         <Sidebar showSidebar={showSidebar} setShowSidebar={setShowSidebar} />
         <TextArea shiftRight={showSidebar} setShiftRight={setShowSidebar} />
-        <CheckUsername />
+        <CheckUsername
+          show={showUsernameModal}
+          onSetShow={(state) => {
+            setShowUsernameModal(state);
+          }}
+        />
       </div>
     </>
   );

--- a/pages/login.tsx
+++ b/pages/login.tsx
@@ -11,13 +11,14 @@ import React from "react";
 const LoginPage = () => {
   // NEXT ROUTER
   const router = useRouter();
-  const { createUser } = useUser();
+  const { createUser, checkUserExists } = useUser();
 
   // AUTH STATE HOOK
   const [authUser, authLoading, authError] = useAuthState(auth, {
     onUserChanged: async (user) => {
       if (!user) return;
-      createUser(user);
+      const existingUser = await checkUserExists(user);
+      !existingUser && createUser(user);
     },
   });
 


### PR DESCRIPTION
This PR makes the following updates:
- Use username in post links instead of UID.
- Use UID in post links if username is not available.
- Clicking on a public note in the dashboard would update the URL.