### PR TITLE
[REFACTOR] Fuse selectedNoteIdAtom with selectedNoteAtom #112

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,3 +52,5 @@ firestore-debug.log
 
 /firebase/
 /firebase/**/*
+
+functions/

--- a/components/common/UserMenu.tsx
+++ b/components/common/UserMenu.tsx
@@ -7,7 +7,6 @@ import {
   BiSun,
 } from "react-icons/bi";
 import { selectedNoteAtom } from "@/stores/postDataAtom";
-import { selectedNoteIdAtom } from "@/stores/selectedChannelIdAtom";
 import { useTheme } from "next-themes";
 import Popover from "../ui/Popover";
 import { auth } from "@/lib/firebase";
@@ -35,7 +34,6 @@ const UserMenu = ({
   children,
 }: UserMenuProps) => {
   const { theme, setTheme } = useTheme();
-  const setSelectedNoteId = useSetAtom(selectedNoteIdAtom);
   const [selectedNote, setSelectedNote] = useAtom(selectedNoteAtom);
 
   return (
@@ -85,10 +83,9 @@ const UserMenu = ({
         <button
           onClick={() => {
             auth.signOut();
-            setSelectedNoteId("");
-
             setSelectedNote((prev) => ({
               ...prev,
+              id: "",
               isPublic: false,
               title: "",
               content: "",

--- a/components/dashboard/Sidebar/PostRow.tsx
+++ b/components/dashboard/Sidebar/PostRow.tsx
@@ -1,9 +1,9 @@
-import { selectedNoteIdAtom } from "@/stores/selectedChannelIdAtom";
 import { isSyncedAtom } from "@/stores/syncedAtom";
 import Skeleton from "react-loading-skeleton";
 import { useAtom, useAtomValue } from "jotai";
 import RemoveMarkdown from "remove-markdown";
 import React from "react";
+import { selectedNoteAtom } from "@/stores/postDataAtom";
 
 type PostRowProps = {
   title: string;
@@ -14,7 +14,7 @@ type PostRowProps = {
 };
 
 const PostRow = ({ title, content, noteId, setShowSidebar }: PostRowProps) => {
-  const [selectedNoteId, setSelectedNoteId] = useAtom(selectedNoteIdAtom);
+  const [selectedNote, setSelectedNote] = useAtom(selectedNoteAtom);
   const synced = useAtomValue(isSyncedAtom);
 
   const switchNotesHandler = async (noteId: string) => {
@@ -24,14 +24,14 @@ const PostRow = ({ title, content, noteId, setShowSidebar }: PostRowProps) => {
       );
       if (!confirm) return;
     }
-    setSelectedNoteId(noteId);
+    setSelectedNote((prev) => ({ ...prev, id: noteId }));
     window.innerWidth <= 768 && setShowSidebar(false);
   };
 
   return (
     <div
       className={`flex cursor-pointer flex-col gap-2 rounded-xl p-4 ${
-        selectedNoteId === noteId
+        selectedNote.id === noteId
           ? "bg-slate-200 dark:bg-slate-700"
           : "bg-slate-50 hover:bg-slate-100 dark:bg-slate-800 dark:hover:bg-slate-700"
       }`}

--- a/components/dashboard/Sidebar/index.tsx
+++ b/components/dashboard/Sidebar/index.tsx
@@ -1,4 +1,3 @@
-import { selectedNoteIdAtom } from "@/stores/selectedChannelIdAtom";
 import { IFirebaseAuth } from "@/types/components/firebase-hooks";
 import { IoMdAddCircle, IoMdRefreshCircle } from "react-icons/io";
 import { FEATURE_FLAGS } from "@/constants/feature-flags";
@@ -39,27 +38,25 @@ const Sidebar = ({
 
   const [selectedNote, setSelectedNote] = useAtom(selectedNoteAtom);
 
-  const setSelectedNoteId = useSetAtom(selectedNoteIdAtom);
-  const selectedNoteId = useAtomValue(selectedNoteIdAtom);
   const synced = useAtomValue(isSyncedAtom);
 
   const { notes, createNote, refreshNotes } = useNotes({ userId: user?.uid });
 
   useEffect(() => {
-    if (!selectedNoteId) return;
-    router.push(`/dashboard/?post=${selectedNoteId}`, undefined, {
+    if (!selectedNote.id) return;
+    router.push(`/dashboard/?post=${selectedNote.id}`, undefined, {
       shallow: true,
     });
-  }, [selectedNoteId]);
+  }, [selectedNote.id]);
 
   useEffect(() => {
     if (!router.query.post) return;
-    setSelectedNoteId(router.query.post as string);
+    setSelectedNote((prev) => ({ ...prev, id: router.query.post as string }));
   }, [router.query.post]);
 
   useEffect(() => {
     refreshNotes();
-  }, [synced, selectedNoteId]);
+  }, [synced, selectedNote.id]);
 
   const newPostClickHandler = async () => {
     setCreatePostLoading(true);
@@ -69,7 +66,7 @@ const Sidebar = ({
       toast.error("Failed to create new post");
       return;
     }
-    setSelectedNoteId(newId);
+    setSelectedNote((prev) => ({ ...prev, id: newId }));
     setCreatePostLoading(false);
     window.innerWidth <= 768 && setShowSidebar(false);
   };

--- a/components/dashboard/TextArea/PostButtons.tsx
+++ b/components/dashboard/TextArea/PostButtons.tsx
@@ -7,7 +7,6 @@ import {
   IoMdTrash,
 } from "react-icons/io";
 import { selectedNoteAtom } from "@/stores/postDataAtom";
-import { selectedNoteIdAtom } from "@/stores/selectedChannelIdAtom";
 import useNotes from "@/components/hooks/useNotes";
 import { isSyncedAtom } from "@/stores/syncedAtom";
 import { useEffect, useState } from "react";
@@ -53,7 +52,6 @@ const PostButtons = ({ shiftRight, editor }: PostButtonsProps) => {
   const [downloadLoading, setDownloadLoading] = useState(false);
 
   // ATOMIC STATE
-  const [selectedNoteId, setSelectedNoteId] = useAtom(selectedNoteIdAtom);
   const [synced, setSynced] = useAtom(isSyncedAtom);
   const [selectedNote, setSelectedNote] = useAtom(selectedNoteAtom);
 
@@ -69,17 +67,17 @@ const PostButtons = ({ shiftRight, editor }: PostButtonsProps) => {
     if (!selectedNote.lastUpdated) return;
     const formattedDate = formatTimeStamp(selectedNote.lastUpdated);
     setLastUpdated(formattedDate);
-  }, [selectedNote.lastUpdated, selectedNoteId]);
+  }, [selectedNote.lastUpdated, selectedNote.id]);
 
   /**
    * Saves the note if not already synced
    */
   const saveNoteHandler = async () => {
-    if (!selectedNoteId || !notes?.find((note) => note.id === selectedNoteId))
+    if (!selectedNote.id || !notes?.find((note) => note.id === selectedNote.id))
       return;
     setSynced(false);
     await updateNote({
-      id: selectedNoteId,
+      id: selectedNote.id,
       title: selectedNote.title,
       content: selectedNote.content,
       public: selectedNote.isPublic,
@@ -92,13 +90,13 @@ const PostButtons = ({ shiftRight, editor }: PostButtonsProps) => {
    * Deletes the note and selects the next note in the list
    */
   const deleteNoteHandler = async () => {
-    if (!notes || !selectedNoteId) return;
+    if (!notes || !selectedNote.id) return;
     // Confirm deletion
     const confirm = window.confirm(
       "Are you sure you want to delete this post?"
     );
     if (!confirm) return;
-    await deleteNote(selectedNoteId);
+    await deleteNote(selectedNote.id);
     await refreshNotes();
     toast.success("Deleted Post!", {
       iconTheme: {
@@ -106,9 +104,9 @@ const PostButtons = ({ shiftRight, editor }: PostButtonsProps) => {
         secondary: "#ffffff",
       },
     });
-    const noteIndex = notes.findIndex((note) => note.id === selectedNoteId);
+    const noteIndex = notes.findIndex((note) => note.id === selectedNote.id);
     const newIndex = noteIndex > 0 ? noteIndex - 1 : noteIndex + 1;
-    setSelectedNoteId(notes[0]?.id || null);
+    setSelectedNote((prev) => ({ ...prev, id: notes[0]?.id || "" }));
   };
 
   const downloadPDFHandler = async () => {
@@ -288,10 +286,10 @@ const PostButtons = ({ shiftRight, editor }: PostButtonsProps) => {
                   isDev
                     ? `http://localhost:3000/${
                         publicUserDetails?.username || publicUserDetails?.uid
-                      }/posts/${selectedNoteId}`
+                      }/posts/${selectedNote.id}`
                     : `https://writedown.app/${
                         publicUserDetails?.username || publicUserDetails?.uid
-                      }/posts/${selectedNoteId}`
+                      }/posts/${selectedNote.id}`
                 );
               }}
             >
@@ -301,7 +299,7 @@ const PostButtons = ({ shiftRight, editor }: PostButtonsProps) => {
                   selectedNote.isPublic &&
                   `https://writedown.app/${
                     publicUserDetails?.username || publicUserDetails?.uid
-                  }/posts/${selectedNoteId}`}
+                  }/posts/${selectedNote.id}`}
                 {process.env.NODE_ENV !== "development" &&
                   !selectedNote.isPublic &&
                   `https://writedown.app/...`}
@@ -310,7 +308,7 @@ const PostButtons = ({ shiftRight, editor }: PostButtonsProps) => {
                   selectedNote.isPublic &&
                   `http://localhost:3000/${
                     publicUserDetails?.username || publicUserDetails?.uid
-                  }/posts/${selectedNoteId}`}
+                  }/posts/${selectedNote.id}`}
                 {process.env.NODE_ENV === "development" &&
                   !selectedNote.isPublic &&
                   `http://localhost:3000/...`}

--- a/components/ui/WritedownEditor.tsx
+++ b/components/ui/WritedownEditor.tsx
@@ -1,4 +1,4 @@
-import { selectedNoteIdAtom } from "@/stores/selectedChannelIdAtom";
+import { selectedNoteAtom } from "@/stores/postDataAtom";
 import { NoteDocument } from "@/types/utils/firebaseOperations";
 import { EditorContent, Editor } from "@tiptap/react";
 import { useAtomValue } from "jotai";
@@ -10,21 +10,21 @@ interface editorProps {
 }
 
 const WritedownEditor = ({ notes, editor }: editorProps) => {
-  const selectedNoteId = useAtomValue(selectedNoteIdAtom);
+  const selectedNote = useAtomValue(selectedNoteAtom);
 
   useEffect(() => {
     if (!editor) return;
     // If there are no notes or no selected note, clear the editor
-    if (!notes || !selectedNoteId) {
+    if (!notes || !selectedNote.id) {
       editor.commands.clearContent();
 
       return;
     }
     // Replace the editor content with the current note content
-    const currentNote = notes.find((note) => note.id === selectedNoteId);
+    const currentNote = notes.find((note) => note.id === selectedNote.id);
     if (!currentNote) return;
     editor.commands.setContent(currentNote.content);
-  }, [selectedNoteId, notes]);
+  }, [selectedNote.id, notes]);
 
   return <EditorContent selected editor={editor} />;
 };

--- a/stores/selectedChannelIdAtom.ts
+++ b/stores/selectedChannelIdAtom.ts
@@ -1,3 +1,0 @@
-import { atom } from "jotai";
-
-export const selectedNoteIdAtom = atom<string | null>(null);


### PR DESCRIPTION
Modified Files:
1. .gitignore
2. components/common/UserMenu.tsx
3. components/dashboard/Sidebar/PostRow.tsx
4. components/dashboard/Sidebar/index.tsx
5. components/dashboard/TextArea/PostButtons.tsx
6. components/dashboard/TextArea/index.tsx
7. components/ui/WritedownEditor.tsx

Deleted Files:
1. stores/selectedChannelIdAtom.ts


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- State management for selected notes has been streamlined, focusing on using the entire note object instead of just the note ID.
  
- **Bug Fixes**
	- Improved consistency in how the selected note is referenced across multiple components, reducing potential errors in note management.

- **Refactor**
	- Removed unnecessary state and atom dependencies related to note IDs, consolidating state management into a single object for clarity and maintainability.

- **Documentation**
	- Updated import references to align with the new state management structure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->